### PR TITLE
Using APITestCase instead of TestCase in ch5/todos/tests.py

### DIFF
--- a/ch5-todo-api/todos/tests.py
+++ b/ch5-todo-api/todos/tests.py
@@ -1,4 +1,3 @@
-from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -6,7 +5,7 @@ from rest_framework.test import APITestCase
 from .models import Todo
 
 
-class TodoModelTest(TestCase):
+class TodoModelTest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.todo = Todo.objects.create(title="First Todo", body="A body of text here")


### PR DESCRIPTION
Hi,
In chapter 5 we wrote tests for `todos` app. Although in the paragraph at the bottom of the page 80 we introduced `APITestCase` and imported it in the `tests.py` module, we didn't use it in the actual code by mistake.
Thanks.