### PR TITLE
class Meta subclassing UserCreationForm was removed

### DIFF
--- a/ch6-blog-api/accounts/forms.py
+++ b/ch6-blog-api/accounts/forms.py
@@ -4,7 +4,7 @@ from .models import CustomUser
 
 
 class CustomUserCreationForm(UserCreationForm):
-    class Meta(UserCreationForm):
+    class Meta:
         model = CustomUser
         fields = UserCreationForm.Meta.fields + ("name",)
 


### PR DESCRIPTION
In ch6-blog-api forms.py file, the Meta class was inheriting from the UserCreationForm class which should not be so. so I simply removed the inheritance.