### PR TITLE
Update settings.py

### DIFF
--- a/ch8-blog-user-auth/django_project/settings.py
+++ b/ch8-blog-user-auth/django_project/settings.py
@@ -159,3 +159,8 @@ CSRF_TRUSTED_ORIGINS = ["http://localhost:3000"]
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"  # new
 
 SITE_ID = 1  # new
+
+REST_AUTH = { # new cause of dj_rest_auth
+    'SESSION_LOGIN': False,
+}
+


### PR DESCRIPTION
Default settings in result return **204**,not a token.

**FILE apps/lib/python3.9/site-packages/dj_rest_auth/registration/views.py**

```
if api_settings.USE_JWT:
    data = {
        'user': user,
        'access_token': self.access_token,
        'refresh_token': self.refresh_token,
    }
    return api_settings.JWT_SERIALIZER(data, context=self.get_serializer_context()).data
elif api_settings.SESSION_LOGIN:
    return None
else:
    return api_settings.TOKEN_SERIALIZER(user.auth_token, context=self.get_serializer_context()).data
```

Django and DRF updates broken something, and in order to work with tokens you need to disable session_login. I waiting for your solution for this problem.